### PR TITLE
added lower case for @user name

### DIFF
--- a/script.js
+++ b/script.js
@@ -55,6 +55,7 @@ async function accountHistoryLoadMore(){
 
 async function usernameSubmitted(){
 	let name = document.getElementById("searchText").value;
+        name = name.toLowerCase();
 	[accounts, accountHistory, delegations, dynamicGlobalProperties] = await Promise.all([
 		steem.api.getAccountsAsync([name]),
 		steem.api.getAccountHistoryAsync(name, -1, INITIAL_FETCH_LIMIT),


### PR DESCRIPTION
Using @user name as "Wefund" or "Lavater" returned no results. Now any uppercase @user names will be automatically changed to lower case strings.