### PR TITLE
script.js: increased INITIAL_FETCH_LIMIT to 1000 for greater accurency

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-const INITIAL_FETCH_LIMIT = 500
+const INITIAL_FETCH_LIMIT = 1000
 let [accounts, accountHistory, delegations, dynamicGlobalProperties] = []
 let delegationHistory
 let sbdPrice, steemPrice = 0


### PR DESCRIPTION
- script.js: increased INITIAL_FETCH_LIMIT to 1000 for greater accuracy 