### PR TITLE
script.js: ignore first trasfer, set initial_fetch to around 7 days

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-const INITIAL_FETCH_LIMIT = 250
+const INITIAL_FETCH_LIMIT = 1000
 let [accounts, accountHistory, delegations, dynamicGlobalProperties] = []
 let delegationHistory
 let sbdPrice, steemPrice = 0

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-const INITIAL_FETCH_LIMIT = 1000
+const INITIAL_FETCH_LIMIT = 250
 let [accounts, accountHistory, delegations, dynamicGlobalProperties] = []
 let delegationHistory
 let sbdPrice, steemPrice = 0
@@ -219,14 +219,19 @@ function roi(delegation){
 	let earnedSteem = 0
 	let earnedSBD = 0
 	let apr = 0
+        let transfer_counter = 0
 	transfers.forEach((transfer) => {
-		let splits = transfer[1].op[1].amount.split(' ', 2)
-		if (splits[1] === 'SBD') {
-			earnedSBD += Number(splits[0])
+		//ignore first transfer
+		if (transfer_counter > 0) {
+			let splits = transfer[1].op[1].amount.split(' ', 2)
+				if (splits[1] === 'SBD') {
+					earnedSBD += Number(splits[0])
+				}
+				if (splits[1] === 'STEEM') {
+					earnedSteem += Number(splits[0])
+				}
 		}
-		if (splits[1] === 'STEEM') {
-			earnedSteem += Number(splits[0])
-		}
+		transfer_counter += 1
 	})
 	let delegatedSP = unitString2Number(delegation.steemPower)
 	apr = (((earnedSBD * sbdPrice / steemPrice) + earnedSteem) / daysDelegated) / delegatedSP * 100 * 365


### PR DESCRIPTION
- ignore first transfer when calculating APR
- set initial_fetch_limit to 250 - around 7 days